### PR TITLE
Set env.bugfixes by default

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -18,6 +18,13 @@ export const webpackFinal = async (config: Configuration, options: Options) => {
 
   const swcFinalOptions: SwcOptions = {
     ...swcOptions,
+    env: {
+      ...(swcOptions?.env ?? {}),
+      // Transpiles the broken syntax to the closest non-broken modern syntax.
+      // E.g. it won't transpile parameter destructuring in Safari
+      // which would break how we detect if the mount context property is used in the play function.
+      bugfixes: swcOptions?.env?.bugfixes ?? true,
+    },
     jsc: {
       ...(swcOptions.jsc ?? {}),
       parser: swcOptions.jsc?.parser ?? {


### PR DESCRIPTION
env. bugfixes ranspiles the broken syntax to the closest non-broken modern syntax.
E.g. it won't transpile parameter destructuring in Safari,
which would break how we detect if the mount context property is used in the play function.
