### PR TITLE
fix: preset.js is esm (node 22.12.0)

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,2 @@
-module.exports = require('./dist/preset.cjs');
+import preset from "./dist/preset.cjs";
+export default preset;


### PR DESCRIPTION
require(esm) is now enabled by default in node [22.12.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.12.0)

```
SB_CORE-SERVER_0002 (CriticalPresetLoadError): Storybook failed to load the following preset: ./.storybook/main.ts.

Please check whether your setup is correct, the Storybook dependencies (and their peer dependencies) are installed correctly and there are no package version clashes.

If you believe this is a bug, please open an issue on Github.

SB_CORE-SERVER_0002 (CriticalPresetLoadError): Storybook failed to load the following preset: /Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js.

Please check whether your setup is correct, the Storybook dependencies (and their peer dependencies) are installed correctly and there are no package version clashes.

If you believe this is a bug, please open an issue on Github.

ReferenceError: module is not defined
    at file:///Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js:1:1
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:395:35)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:329:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1414:24)
    at Module._compile (node:internal/modules/cjs/loader:1547:5)
    at node:internal/modules/cjs/loader:1677:16
    at Object.newLoader (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:4833:24)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)

More info: 

    at loadPreset (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/common/index.cjs:16477:13)

More info: 

    at loadPreset (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/common/index.cjs:16477:13)
    at async Promise.all (index 2)
    at async loadPresets (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/common/index.cjs:16487:55)
    at async getPresets (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/common/index.cjs:16520:11)
    at async buildStaticStandalone (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/core-server/index.cjs:35384:11)
    at async withTelemetry (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/core-server/index.cjs:35757:12)
    at async build (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/cli/bin/index.cjs:2555:3)
    at async s.<anonymous> (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/cli/bin/index.cjs:2661:7)
WARN   Failed to load preset: {"type":"presets","name":"/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js"} on level 1
Error [ERR_REQUIRE_CYCLE_MODULE]: Cannot require() ES Module /Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js in a cycle. (from /Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/core/dist/common/index.cjs)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:315:15)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1414:24)
    at Module._compile (node:internal/modules/cjs/loader:1547:5)
    at node:internal/modules/cjs/loader:1677:16
    at Object.newLoader (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:4833:24)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
file:///Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js:1
module.exports = require('./dist/preset.cjs');
^

ReferenceError: module is not defined
    at file:///Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/@storybook/addon-webpack5-compiler-swc/preset.js:1:1
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:395:35)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:329:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1414:24)
    at Module._compile (node:internal/modules/cjs/loader:1547:5)
    at node:internal/modules/cjs/loader:1677:16
    at Object.newLoader (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (/Users/d.suvorov/Documents/VKCOM/VKUI/node_modules/esbuild-register/dist/node.js:4833:24)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)

Node.js v22.12.0
```
