### PR TITLE
fix: streamline SWC options handling in webpackFinal

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -9,31 +9,33 @@ const virtualModuleFiles = [
 ];
 
 export const webpackFinal = async (config: Configuration, options: Options) => {
-  const swcOptions = await options.presets.apply("swc", {}, options);
-  const typescriptOptions = await options.presets.apply(
-    "typescript",
-    {},
-    options,
-  );
-
-  const swcFinalOptions: SwcOptions = {
-    ...swcOptions,
+  const swcDefaultOptions: SwcOptions = {
     env: {
-      ...(swcOptions?.env ?? {}),
       // Transpiles the broken syntax to the closest non-broken modern syntax.
       // E.g. it won't transpile parameter destructuring in Safari
       // which would break how we detect if the mount context property is used in the play function.
-      bugfixes: swcOptions?.env?.bugfixes ?? true,
+      bugfixes: true,
     },
     jsc: {
-      ...(swcOptions.jsc ?? {}),
-      parser: swcOptions.jsc?.parser ?? {
+      parser: {
         syntax: "typescript",
         tsx: true,
         dynamicImport: true,
       },
     },
   };
+
+  const swcOptions = await options.presets.apply(
+    "swc",
+    swcDefaultOptions,
+    options,
+  );
+
+  const typescriptOptions = await options.presets.apply(
+    "typescript",
+    {},
+    options,
+  );
 
   config.module = {
     ...(config.module || {}),
@@ -46,7 +48,7 @@ export const webpackFinal = async (config: Configuration, options: Options) => {
         use: [
           {
             loader: require.resolve("swc-loader"),
-            options: swcFinalOptions,
+            options: swcOptions,
           },
         ],
         include: [getProjectRoot()],


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-webpack5-compiler-swc/issues/10

[Storybook documentation](https://storybook.js.org/docs/api/main-config/main-config-swc) suggests you can customize the swc config, by a function that accepts the default config:

```js
swc: (config: Options, options): Options => {
    return {
      ...config,
      // Apply your custom SWC configuration
    };
  },
```

`config` is an empty object, though. In this PR, deep merging the user's settings with the SWC default options no longer happens. Instead, the default SWC loader settings are passed as options into the `swc` preset function, and the user is responsible for returning the whole SWC configuration from the preset hook. This can lead to a breaking change!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.13.b38e7cf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-webpack5-compiler-swc@2.0.0--canary.13.b38e7cf.0
  # or 
  yarn add @storybook/addon-webpack5-compiler-swc@2.0.0--canary.13.b38e7cf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
